### PR TITLE
Fix accessibility star

### DIFF
--- a/src/components/ui/form/Input.astro
+++ b/src/components/ui/form/Input.astro
@@ -36,7 +36,7 @@ const inputTextClass = getInputTextColor(background);
         class={`block text-sm font-medium mb-1 ${labelClass}`}
     >
         {label}
-        {required && <span class="text-red-500">*</span>}
+        {required && <span class="text-red-500" aria-hidden="true">*</span>}
     </label>
     <input 
         type={type}


### PR DESCRIPTION
## Summary
- add `aria-hidden` to the required field asterisk

## Testing
- `npm run check` *(fails: Can't find lefthook in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_688cdcb824cc832683d7628167bfff09